### PR TITLE
3D Molecule View Enhancements

### DIFF
--- a/backend/tests/utils/test_api.py
+++ b/backend/tests/utils/test_api.py
@@ -29,7 +29,7 @@ class TestModelRequestGroup:
     def test_model_get_response_format(self, client, mocker):
         mocker.patch('backend.utils.api.sh', backend.tests.mocks.mock_sh.MockSH())
         response = client.get(f'/users/{_test_user_id}/models')
-        assert response.status_code == 200, 'Request should have worked'
+        assert response.status_code in range(200, 300), 'Request should have worked'
         assert type(response.json) == list, 'Response json should be a list'
         assert len(response.json) == 0, 'Response list should be empty'
 
@@ -72,7 +72,7 @@ class TestModelRequestGroup:
         mocker.patch('backend.utils.api.sh.get_dataset_summaries', return_value=sh_datasets)
         mocker.patch('backend.utils.api.sh.get_base_model', return_value=base_models.get('Test A'))
         response = client.get(f'/users/{_test_user_id}/models')
-        assert response.status_code == 200, 'Request should have worked'
+        assert response.status_code in range(200, 300), 'Request should have worked'
         assert type(response.json) == list, 'Response json should be a list'
         response_json = response.json
         for model_id, model in sh_models.items():
@@ -111,16 +111,16 @@ class TestModelRequestGroup:
         mocker.patch('backend.utils.api.sh.add_model', return_value=model_id)
         response = client.patch(f'/users/{_test_user_id}/models',
                                 json={'name': model_name, 'parameters': parameters, 'baseModel': base_model})
-        assert response.status_code == 201, 'Request should have worked'
+        assert response.status_code in range(200, 300), 'Request should have worked'
         assert response.is_json, 'Response should be a json, just containing the model_id'
         assert response.json == model_id, 'Response should be the expected model_id'
 
 
-class TestMoleculeRequestGroup:
+class TestMoleculesRequestGroup:
     def test_molecule_get_response_format(self, client, mocker):
         mocker.patch('backend.utils.api.sh.get_molecules', return_value={})
         response = client.get(f'/users/{_test_user_id}/molecules')
-        assert response.status_code == 200, 'Request should have worked'
+        assert response.status_code in range(200, 300), 'Request should have worked'
         assert response.is_json, 'Response should be a json'
         assert type(response.json) == list, 'Response json should be a list'
         assert len(response.json) == 0, 'List should be empty'
@@ -143,7 +143,7 @@ class TestMoleculeRequestGroup:
         mocker.patch('backend.utils.api.sh.get_fitting_summary', return_value=sh_fitting_summary)
         mocker.patch('backend.utils.api.sh.get_model_summary', return_value=sh_model_summary)
         response = client.get(f'/users/{_test_user_id}/molecules')
-        assert response.status_code == 200, 'Request should have worked'
+        assert response.status_code in range(200, 300), 'Request should have worked'
         assert type(response.json) == list, 'Response json should be a list'
         assert response.json == expected_molecules_output, 'Response json should be formatted like expected_output'
 
@@ -158,7 +158,7 @@ class TestMoleculeRequestGroup:
         mocker.patch('backend.utils.api.mf.is_valid_molecule', return_value=True)
         response = client.patch(f'/users/{_test_user_id}/molecules',
                                 json={'name': test_mol_name, 'smiles': test_smiles, 'cml': test_cml})
-        assert response.status_code == 201, 'Request should have worked'
+        assert response.status_code in range(200, 300), 'Request should have worked'
         assert response.json is None, 'Response json should be None'
 
     def test_molecule_patch_invalid(self, client, mocker):
@@ -173,7 +173,7 @@ class TestFittingRequestGroup:
     def test_fitting_get_response_format(self, client, mocker):
         mocker.patch('backend.utils.api.sh', backend.tests.mocks.mock_sh.MockSH())
         response = client.get(f'/users/{_test_user_id}/fittings')
-        assert response.status_code == 200, 'Request should have succeeded'
+        assert response.status_code in range(200, 300), 'Request should have succeeded'
         assert response.is_json, 'Response should be a json'
         assert type(response.json) is list, 'Response should be a list'
         assert len(response.json) == 0, 'List should be empty'
@@ -218,7 +218,7 @@ class TestFittingRequestGroup:
         mocker.patch('backend.utils.api.sh.get_model_summary', mock_sh.get_model_summary)
         mocker.patch('backend.utils.api.sh.get_dataset_summaries', return_value=sh_datasets)
         response = client.get(f'/users/{_test_user_id}/fittings')
-        assert response.status_code == 200, 'Request should have succeeded'
+        assert response.status_code in range(200, 300), 'Request should have succeeded'
         response_json = response.json
         for fitting_id, fitting in sh_fittings.items():
             model_name = 'n/a'
@@ -253,7 +253,7 @@ class TestUserRequestGroup:
         sh_model_mock = mocker.patch('backend.utils.api.sh.add_model')
         response = client.post(f'/users', json={'username': test_username})
         user_id = str(hashlib.sha1(test_username.encode('utf-8'), usedforsecurity=False).hexdigest())
-        assert response.status_code == 201, 'Request should have worked'
+        assert response.status_code in range(200, 300), 'Request should have worked'
         assert response.is_json, 'Response should be a json'
         assert response.json == {'userID': user_id}, 'json should contain the user id'
         sh_mol_mock.assert_called_once()
@@ -267,7 +267,7 @@ class TestUserRequestGroup:
     def test_delete_user_response(self, client, mocker):
         mocker.patch('backend.utils.api.sh', backend.tests.mocks.mock_sh.MockUserDelSH())
         response = client.delete(f'/users/{_test_user_id}')
-        assert response.status_code == 200, 'Request should have worked'
+        assert response.status_code in range(200, 300), 'Request should have worked'
         assert response.json is None, 'Response should have a json'
 
     def test_delete_user_internal_error_response(self, client, mocker):
@@ -287,7 +287,7 @@ class TestDatasetRequestGroup:
     def test_dataset_get_response_format(self, client, mocker):
         mocker.patch('backend.utils.api.sh.get_dataset_summaries', return_value={})
         response = client.get(f'/datasets')
-        assert response.status_code == 200, 'Request should have succeeded'
+        assert response.status_code in range(200, 300), 'Request should have succeeded'
         assert response.is_json, 'Response should be a json'
         assert type(response.json) == list, 'Response JSON should be a list'
         assert len(response.json) == 0, 'List should be empty'
@@ -307,7 +307,7 @@ class TestDatasetRequestGroup:
         mocker.patch('backend.utils.api.sh.get_dataset_summaries', return_value=sh_datasets)
         response = client.get(f'/datasets')
         response_json = response.json
-        assert response.status_code == 200, 'Request should have succeeded'
+        assert response.status_code in range(200, 300), 'Request should have succeeded'
         for dataset_id, dataset in sh_datasets.items():
             converted_set = dict()
             converted_set |= {'name': dataset.get('name')}
@@ -321,7 +321,7 @@ class TestBaseModelRequestGroup:
     def test_base_model_get_response_format(self, client, mocker):
         mocker.patch('backend.utils.api.sh.get_base_models', return_value={})
         response = client.get(f'/baseModels')
-        assert response.status_code == 200, 'Request should have succeeded'
+        assert response.status_code in range(200, 300), 'Request should have succeeded'
         assert response.is_json, 'Response should be a json list'
         assert type(response.json) == list, 'Response should be a list'
         assert len(response.json) == 0, 'Response should be an empty list'
@@ -388,7 +388,7 @@ class TestAnalyzeRequestGroup:
     def test_analyze_post_response(self, test_analysis, client, mocker):
         mocker.patch('backend.utils.api.ml.analyze', return_value=test_analysis)
         response = client.post(f'/users/{_test_user_id}/analyze', json={})
-        assert response.status_code == 200, 'Response should have worked'
+        assert response.status_code in range(200, 300), 'Response should have worked'
         assert response.is_json, 'Response should be a json'
         assert response.json == test_analysis, 'Response json should match analysis'
 
@@ -420,7 +420,7 @@ class TestTrainRequestGroup:
             labels=labels,
             epochs=epochs,
             batch_size=batch_size)
-        assert response.status_code == 200, 'Expected request to work'
+        assert response.status_code in range(200, 300), 'Expected request to work'
         assert response.json, 'Expecting response to be "True"'
 
     def test_train_busy_post_response(self, client, mocker):
@@ -440,7 +440,7 @@ class TestTrainRequestGroup:
         mocker.patch('backend.utils.api.ml.is_training_running', return_value=False)
         mocker.patch('backend.utils.api.sh.get_fitting_summary', return_value={'epochs': 50})
         response = client.patch(f'/users/{_test_user_id}/train', json={'fittingID': fitting_id, 'epochs': epochs})
-        assert response.status_code == 200, 'Expecting request to work'
+        assert response.status_code in range(200, 300), 'Expecting request to work'
         assert response.json
 
     def test_train_busy_patch_response(self, client, mocker):
@@ -491,13 +491,13 @@ class TestScoreboardRequestGroup:
     def test_scoreboard_get(self, sh_scoreboards, client, mocker):
         mocker.patch('backend.utils.api.sh.get_scoreboard_summaries', return_value=sh_scoreboards)
         response = client.get(f'/scoreboard')
-        assert response.status_code == 200, 'Request should have worked'
+        assert response.status_code in range(200, 300), 'Request should have worked'
         assert response.json == list(sh_scoreboards.values())
 
     def test_scoreboard_delete(self, client, mocker):
         delete_mock = mocker.patch('backend.utils.api.sh.delete_scoreboard_fittings', return_value=None)
         response = client.delete(f'/scoreboard')
-        assert response.status_code == 200, 'Request should have worked'
+        assert response.status_code in range(200, 300), 'Request should have worked'
         assert response.json is None, 'No response json expected'
         delete_mock.assert_called_once()
 
@@ -510,7 +510,7 @@ class TestScoreboardRequestGroup:
     def test_scoreboard_delete_single(self, scoreboard_id, client, mocker):
         delete_mock = mocker.patch('backend.utils.api.sh.delete_scoreboard_fitting', return_value=None)
         response = client.delete(f'/scoreboard/{scoreboard_id}')
-        assert response.status_code == 200, 'Request should have worked'
+        assert response.status_code in range(200, 300), 'Request should have worked'
         assert response.json is None, 'No response json expected'
         delete_mock.assert_called_once_with(scoreboard_id)
 
@@ -527,8 +527,20 @@ def test_histogram_get(dataset_histograms, dataset_id, labels, client, mocker):
     old_hist = copy.deepcopy(dataset_histograms)
     response = client.get(f'/histograms/{dataset_id}/{labels}')
 
-    assert response.status_code == 200, 'Request should have succeeded'
+    assert response.status_code in range(200, 300), 'Request should have succeeded'
     for x in labels.split(','):
         assert response.json[x] is not None, 'Expected response for labels'
         assert response.json[x]['binEdges'] == old_hist[x]['bin_edges'], 'Expected bin_edges to have been renamed'
         assert response.json[x].get('bin_edges') is None, 'Expected bin_edges to have been removed'
+
+@pytest.mark.parametrize(
+    'b64smiles, mocked_rval, expected_response_range',
+    [
+        ('WzEzQ10vQz1DKC9bKl0pQw%3D%3D', 'This is a stand-in for a cml string', range(200, 300)),
+        ('Q0MoWypdKT1DMShbMTNDXSlDKEMpKEMpKEMxKUM%3D', None, {422})
+    ]
+)
+def test_molecule_3d_get(b64smiles, mocked_rval, expected_response_range, client, mocker):
+    mocker.patch('backend.utils.molecule_formats.smiles_to_3DCML', return_value=mocked_rval)
+    response = client.get(f'/molecule/{b64smiles}')
+    assert response.status_code in expected_response_range, 'Request should have a code in the expected range'

--- a/backend/tests/utils/test_molecule_formats.py
+++ b/backend/tests/utils/test_molecule_formats.py
@@ -87,3 +87,21 @@ def test_is_valid_molecule(test_smiles, chem_output, expected_validity, mocker):
     mocker.patch('backend.utils.molecule_formats.Chem.SanitizeMol', return_value=0)
     validity = mf.is_valid_molecule(test_smiles)
     assert validity == expected_validity, 'Expected invalid smiles to be invalid'
+
+
+@pytest.mark.parametrize(
+    'test_smiles',
+    [
+        ('O'),
+        ('COO')
+    ]
+)
+def test_working_3d_generation(test_smiles):
+    cml_code = mf.smiles_to_3DCML(test_smiles)
+    assert cml_code is not None, 'Expecting something'
+    assert type(cml_code) is str, 'Expecting a string'
+
+
+def test_faulty_3d_generation():
+    cml_code = mf.smiles_to_3DCML('awdsda')
+    assert cml_code is None, 'Expecting None on faulty SMILES code'

--- a/backend/utils/api.py
+++ b/backend/utils/api.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import sched
 import time
+import base64
 
 from flask import Flask
 from flask_cors import CORS
@@ -153,9 +154,8 @@ class Molecules(Resource):
 
 
 class Molecule(Resource):
-    def put(self):
-        args = parser.parse_args()
-        smiles = args['smiles']
+    def get(self, smiles):
+        smiles = base64.b64decode(smiles).decode('utf8')
         converted = mf.smiles_to_3DCML(smiles)
         if converted:
             return converted, 200
@@ -450,7 +450,7 @@ api.add_resource(Scoreboard, '/scoreboard/<fitting_id>', '/scoreboard')
 api.add_resource(Datasets, '/datasets')
 api.add_resource(Histograms, '/histograms/<dataset_id>/<labels>')
 api.add_resource(BaseModels, '/baseModels')
-api.add_resource(Molecule, '/molecule')
+api.add_resource(Molecule, '/molecule/<smiles>')
 
 
 # SocketIO event listeners/senders

--- a/backend/utils/api.py
+++ b/backend/utils/api.py
@@ -152,6 +152,16 @@ class Molecules(Resource):
         return None, 422
 
 
+class Molecule(Resource):
+    def put(self):
+        args = parser.parse_args()
+        smiles = args['smiles']
+        converted = mf.smiles_to_3DCML(smiles)
+        if converted:
+            return converted, 200
+        return None, 422
+
+
 class Fittings(Resource):
     """
     GET a list of all fittings for given user ID
@@ -393,7 +403,7 @@ class Train(Resource):
                                   labels=labels,
                                   epochs=args['epochs'],
                                   batch_size=args['batchSize'])
-        return True, 200
+        return True, 202
 
     def patch(self, user_id):
         """
@@ -416,7 +426,7 @@ class Train(Resource):
                                   user_id=user_id,
                                   fitting_id=args['fittingID'],
                                   epochs=args['epochs'])
-        return (fitting_summary.get('epochs') + args['epochs']), 200
+        return (fitting_summary.get('epochs') + args['epochs']), 202
 
     def delete(self, user_id):
         """
@@ -440,6 +450,7 @@ api.add_resource(Scoreboard, '/scoreboard/<fitting_id>', '/scoreboard')
 api.add_resource(Datasets, '/datasets')
 api.add_resource(Histograms, '/histograms/<dataset_id>/<labels>')
 api.add_resource(BaseModels, '/baseModels')
+api.add_resource(Molecule, '/molecule')
 
 
 # SocketIO event listeners/senders

--- a/backend/utils/api.py
+++ b/backend/utils/api.py
@@ -154,8 +154,17 @@ class Molecules(Resource):
 
 
 class Molecule(Resource):
-    def get(self, smiles):
-        smiles = base64.b64decode(smiles).decode('utf8')
+    """
+    GET a cml document for a given base64-encoded smiles code
+    """
+    def get(self, b64_smiles) -> tuple[(str | None), int]:
+        """
+        GET a CML string containing a 3D conversion of a base64 encoded smiles code
+
+        :param b64_smiles: A base64 encoded smiles code
+        :return: Tuple of the CML-String and a response code, or None and a response code
+        """
+        smiles = base64.b64decode(b64_smiles).decode('utf8')
         converted = mf.smiles_to_3DCML(smiles)
         if converted:
             return converted, 200
@@ -450,7 +459,7 @@ api.add_resource(Scoreboard, '/scoreboard/<fitting_id>', '/scoreboard')
 api.add_resource(Datasets, '/datasets')
 api.add_resource(Histograms, '/histograms/<dataset_id>/<labels>')
 api.add_resource(BaseModels, '/baseModels')
-api.add_resource(Molecule, '/molecule/<smiles>')
+api.add_resource(Molecule, '/molecule/<b64_smiles>')
 
 
 # SocketIO event listeners/senders

--- a/backend/utils/molecule_formats.py
+++ b/backend/utils/molecule_formats.py
@@ -25,7 +25,7 @@ def smiles_to_3DCML(smiles):
         AllChem.EmbedMolecule(m)
         return Chem.MolToCMLBlock(m)
 
-    except:
+    except (IndexError, ValueError, TypeError):
         print(f'ERROR: Could not generate proper 3D Coordinates for "{smiles}"')
         return None
 

--- a/backend/utils/molecule_formats.py
+++ b/backend/utils/molecule_formats.py
@@ -18,7 +18,13 @@ def is_valid_molecule(smiles):
         return Chem.SanitizeMol(m, catchErrors=True) == 0
 
 
-def smiles_to_3DCML(smiles):
+def smiles_to_3DCML(smiles: str) -> str | None:
+    """
+    Converts a given smiles code to a CML string with (mostly) correct 3D coordinates.
+
+    :param smiles: A smiles code
+    :return: CML string on success, None on error.
+    """
     try:
         m = Chem.MolFromSmiles(smiles)
         m = Chem.AddHs(m)

--- a/backend/utils/molecule_formats.py
+++ b/backend/utils/molecule_formats.py
@@ -18,6 +18,18 @@ def is_valid_molecule(smiles):
         return Chem.SanitizeMol(m, catchErrors=True) == 0
 
 
+def smiles_to_3DCML(smiles):
+    try:
+        m = Chem.MolFromSmiles(smiles)
+        m = Chem.AddHs(m)
+        AllChem.EmbedMolecule(m)
+        return Chem.MolToCMLBlock(m)
+
+    except:
+        print(f'ERROR: Could not generate proper 3D Coordinates for "{smiles}"')
+        return None
+
+
 def smiles_to_fingerprint(smiles, fingerprint_size=128, radius=2):
     """
     Converts a smiles code to a fingerprint vector with the given parameters

--- a/backend/utils/molecule_formats.py
+++ b/backend/utils/molecule_formats.py
@@ -28,7 +28,9 @@ def smiles_to_3DCML(smiles: str) -> str | None:
     try:
         m = Chem.MolFromSmiles(smiles)
         m = Chem.AddHs(m)
-        AllChem.EmbedMolecule(m)
+        status = AllChem.EmbedMolecule(m, maxAttempts=1000)
+        if status != 0:
+            raise ValueError
         return Chem.MolToCMLBlock(m)
 
     except (IndexError, ValueError, TypeError):

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -199,11 +199,9 @@ export default {
   },
 
   /**
-   * Requests to add a molecule for the current user
+   * Requests proper 3D coordinates for a specific SMILES string
    * @param smiles {string} SMILES string of the molecule
-   * @param cml {string} CML string of the molecule
-   * @param name {string} Name of the molecule
-   * @returns {Promise<AxiosResponse<any>>} Promise that returns the server response data (null) without exception handling
+   * @returns {Promise<AxiosResponse<any>>} Promise that returns the server response data without exception handling
    */
   async get3DMolecule(smiles) {
     return api
@@ -213,6 +211,13 @@ export default {
       })
   },
 
+  /**
+   * Requests to add a molecule for the current user
+   * @param smiles {string} SMILES string of the molecule
+   * @param cml {string} CML string of the molecule
+   * @param name {string} Name of the molecule
+   * @returns {Promise<AxiosResponse<any>>} Promise that returns the server response data (null) without exception handling
+   */
   async addMolecule(smiles, cml, name) {
     return api
       .patch(`/users/${userID}/molecules`, {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -205,6 +205,16 @@ export default {
    * @param name {string} Name of the molecule
    * @returns {Promise<AxiosResponse<any>>} Promise that returns the server response data (null) without exception handling
    */
+  async get3DMolecule(smiles) {
+    return api
+      .put(`/molecule`, {
+        smiles,
+      })
+      .then((response) => {
+        return response.data
+      })
+  },
+
   async addMolecule(smiles, cml, name) {
     return api
       .patch(`/users/${userID}/molecules`, {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -207,9 +207,7 @@ export default {
    */
   async get3DMolecule(smiles) {
     return api
-      .put(`/molecule`, {
-        smiles,
-      })
+      .get(`/molecule/${encodeURIComponent(btoa(smiles))}`)
       .then((response) => {
         return response.data
       })

--- a/frontend/src/components/molecules/MoleculeRenderer.js
+++ b/frontend/src/components/molecules/MoleculeRenderer.js
@@ -13,7 +13,6 @@ chemViewer.setEnableToolbar(true)
 // only allow these tools
 chemViewer.setToolButtons([
   'molDisplayType',
-  'molHideHydrogens',
   'zoomIn',
   'zoomOut',
   'rotateLeft',

--- a/frontend/src/routes/MoleculesPage.js
+++ b/frontend/src/routes/MoleculesPage.js
@@ -228,6 +228,12 @@ function MoleculeView({ selectedMolecule, onSave }) {
     }
   }
 
+  /**
+   * Updates the chemDocument shown by the 3D viewer by sending the current molecule to the backend for conversion.
+   * In case the molecule can't be converted, it uses the regular 3D-ification provided by Kekule.
+   * If there is no drawn molecule, it makes sure the 3D View is blank.
+   * @returns {Promise<AxiosResponse<*> | void>} A promise that's resolved when the api call is done. Or nothing
+   */
   async function updateViewerDoc() {
     if (moleculeDoc && moleculeDoc.getChildCount() > 0) {
       const smiles = Kekule.IO.saveFormatData(moleculeDoc.getChildAt(0), 'smi')
@@ -244,7 +250,11 @@ function MoleculeView({ selectedMolecule, onSave }) {
     }
   }
 
-  function changeView() {
+  /**
+   * Function called when switching between 2D and 3D views.
+   * Handles variable changes required for the process to work.
+   */
+  async function changeView() {
     if (!show3D) {
       setConverting(true)
       updateViewerDoc()
@@ -256,7 +266,7 @@ function MoleculeView({ selectedMolecule, onSave }) {
   }
 
   React.useEffect(() => {
-    updateViewerDoc()
+    updateViewerDoc().then()
   }, [moleculeDoc])
 
   return (
@@ -328,7 +338,7 @@ function MoleculeView({ selectedMolecule, onSave }) {
           endIcon={!converting ? <VisibilityIcon /> : null}
           sx={{ ml: 12 }}
         >
-          Switch to {show3D ? '2D-Editor' : '3D-Viewer'}{' '}
+          Switch to {show3D ? '2D-Editor' : '3D-Viewer'}
           {converting ? (
             <CircularProgress size="16px" color="inherit" sx={{ ml: 1 }} />
           ) : null}

--- a/frontend/src/routes/MoleculesPage.js
+++ b/frontend/src/routes/MoleculesPage.js
@@ -229,7 +229,7 @@ function MoleculeView({ selectedMolecule, onSave }) {
   }
 
   async function updateViewerDoc() {
-    if (moleculeDoc) {
+    if (moleculeDoc && moleculeDoc.getChildCount() > 0) {
       const smiles = Kekule.IO.saveFormatData(moleculeDoc.getChildAt(0), 'smi')
       return api
         .get3DMolecule(smiles)
@@ -239,16 +239,17 @@ function MoleculeView({ selectedMolecule, onSave }) {
           }
         })
         .catch(() => setViewerDoc(moleculeDoc))
+    } else {
+      setViewerDoc(new Kekule.ChemDocument())
     }
   }
 
   function changeView() {
     if (!show3D) {
       setConverting(true)
-      updateViewerDoc().then(() => {
-        setConverting(false)
-        setShow3D(true)
-      })
+      updateViewerDoc()
+        .then(() => setShow3D(true))
+        .finally(() => setConverting(false))
     } else {
       setShow3D(false)
     }


### PR DESCRIPTION
Changelog:

- Added calculation of proper 3D Coordinates to backend. These coordinates are fetched by the frontend when the "Change View" Button is pressed. On Error there's a fallback to display the old 3D molecule (highly inaccurate)
- Removed ability to toggle hydrogen atoms (because of the sheer amount of console errors that caused)
- Added tests for new functions

Tangentially related and thus in this PR:
- Updated API tests to expect response codes from 200-300 in case of success
- Changed response codes of Training Requests to 202 from 200 (Indicating that it's not done processing, just started)


Notes:
- I tried to use get query parameters but could not get it to work with flask restful, so we're using path parameters like everywhere else. Maybe we can take another look at this while doing #14 
- I also tried to work on #1 and found no working way to convert Touch events to Mouse events accepted by the 3D Viewer.